### PR TITLE
fix: 타입 에러 해결

### DIFF
--- a/src/components/product/molecules/TagInput.tsx
+++ b/src/components/product/molecules/TagInput.tsx
@@ -14,7 +14,7 @@ const TagInput = () => {
   const [tags, setTags] = useState<string[]>([])
   const [tag, setTag] = useState<string>('')
 
-  const addTag = (e: InputEvent) => {
+  const addTag = (e: React.ChangeEvent<HTMLInputElement>) => {
     const target = e.target as HTMLInputElement
     if (target) {
       setTag(target.value)


### PR DESCRIPTION
- addTag() 함수 파라미터 타입 에러 해결

### 📝PR Description
이슈 번호 : #12

### 🔨작업 내용
- [V] 빌드 fail 에러 해결
- [ ]

### 💎결과 (사진 및 작업 결과)
함수의 파라미터의 타입을 잘못 지정하여 맞게 수정하였습니다.

<img width="464" alt="image" src="https://github.com/todaysneighbor/front/assets/121751626/b850fc63-bf57-496f-8c2e-cce0ba5e65a9">
